### PR TITLE
Updating asgardcms vendor to idavoll core module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": ">=5.6.4",
         "composer/installers": "~1.0",
-        "asgardcms/core-module": "~2.0"
+        "idavoll/core-module": "~2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",


### PR DESCRIPTION
Solved the problem for installing `asgardcms/attribute-module` which was using `asgardcms/core-module` and requires `nwidart/laravel-modules ~0.11` during installing.
